### PR TITLE
Remove keywords argument added

### DIFF
--- a/R/add_summary_table.R
+++ b/R/add_summary_table.R
@@ -6,16 +6,17 @@
 #' @param middle vector of arrow image calls which will appear in middle column
 #' @param right vector of descriptions of key points which will appear in right column
 #' @param key_words vector of key change words to highlight in right column. A preloaded vector of these key words is already included, but additional words can be added as desired.
+#' @param key_words character vector of standard key words you would NOT like to highlight in bold (defaults to NULL)
 #' @param format string which identifies the outputs you would like three-column table to appear in. Set to HTML as default.
 #' @export
 #' @name add_summary_table
 #' @title Produce summary table for key points in conditional format
-add_summary_table <- function(left, middle, right, key_words = NULL, format = "html"){
+add_summary_table <- function(left, middle, right, key_words = NULL, key_words_remove = NULL, format = "html"){
 
   left <- bold_text(left)
 
   if (knitr::opts_knit$get("rmarkdown.pandoc.to") %in% format){
-    right_bolded <- bold_key_words(right, key_words = key_words)
+    right_bolded <- bold_key_words(right, key_words = key_words, key_words_remove = key_words_remove)
     html_table <- data.frame(left, right_bolded)
     colnames(html_table) <- NULL
     knitr::kable(html_table, format = "markdown")

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -1,12 +1,20 @@
 #' Compares summary points to vector of words indicating change, and highlights relevant words in bold.
 #' @param data character vector of summary points
 #' @param key_words character vector of additional words you would like to highlight in bold (defaults to NULL)
+#' @param key_words character vector of standard key words you would NOT like to highlight in bold (defaults to NULL)
 #' @name bold_key_words
 #' @title Highlight in bold key words in summary text
-bold_key_words <- function(data, key_words = NULL) {
+bold_key_words <- function(data, key_words = NULL, key_words_remove = NULL) {
   ##Concatenate chosen key words with pre-existing list
   key_words <- c(key_words, "decreasing", "decreased", "down", "lower", "fall", "decrease", "fell",
                  "increasing", "increased", "up", "risen", "increase", "rose", "stable", "no change")
+
+  #If key words to remove is not NULL, remove listed words from key_words
+  if(!is.null(key_words_remove)){
+    key_words <-  key_words[!(key_words %in% key_words_remove)]
+  }
+
+
   temp <- data
   for(i in 1:length(key_words)){
     sub_words <- paste0(" **", key_words[i], "** ")
@@ -15,9 +23,10 @@ bold_key_words <- function(data, key_words = NULL) {
     bracket_search_words <- paste0("\\(", key_words[i], " ")
     temp <- gsub(search_words, sub_words, temp, ignore.case = T)
     temp <- gsub(bracket_search_words, bracket_sub_words, temp, ignore.case = T)
-    }
+  }
   return(temp)
 }
+
 
 
 #' Converts image file names to a dataframe, with a field containing the


### PR DESCRIPTION
Added key_words_remove argument to allow people to remove key words they don't want to be in bold. This defaults to NULL, but a vector of key words from the standard list can be passed to it to stop them appearing in bold 